### PR TITLE
feat. optimize docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,13 @@
-FROM node:lts-alpine
+FROM node:lts-alpine AS builder
 
 RUN apk update
-RUN apk add xdg-utils
-
 RUN npm install -g pnpm
 
 WORKDIR /app
-
 COPY . .
 
-RUN pnpm install
+RUN pnpm install && pnpm run build
 
-# convert csv to json
-# automatically executed when postinstall
-RUN pnpm convert
-
-EXPOSE 3333
-
-ENTRYPOINT ["pnpm", "dev"]
+FROM nginx:stable-alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pnpm dev
 # 从 Docker Hub 拉取最新的镜像
 docker pull yunyoujun/cook:latest
 # 新建并启动容器，然后打开 http://localhost:3333
-docker run -it -d --name cook -p 3333:3333 yunyoujun/cook:latest
+docker run -it -d --name cook -p 3333:80 yunyoujun/cook:latest
 
 # 启动与停止
 docker start cook
@@ -66,7 +66,7 @@ docker stop cook
 # 本地构建
 docker build . -t yourname/cook:localdev
 # 启动容器，然后打开 http://localhost:3333
-docker run -it -d --name cook -p 3333:3333 yourname/cook:localdev
+docker run -it -d --name cook -p 3333:80 yourname/cook:localdev
 ```
 
 ## 致谢


### PR DESCRIPTION
Use SSG prerender with Nginx to serve the static HTML output.

- This Dockerfile use npm for better-constructing speed.
- The output artifact image size is `22.5MB`, which is much smaller than previous one (`108.68 MB`) and easy to distrubute.
