### PR TITLE
chore(release): v2.0.0-beta.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cook",
   "type": "module",
-  "version": "2.0.0-beta.13",
+  "version": "2.0.0-beta.14",
   "private": true,
   "packageManager": "pnpm@11.21.0",
   "engines": {


### PR DESCRIPTION
## Release

Prepare `v2.0.0-beta.14` for the approved Cook production rollout.

This release publishes the refreshed cross-platform icon, the “食用手册” native display name, and the pnpm/Corepack CI compatibility fix to the EdgeOne-backed production domain.

## Pre-release validation

- Cook PR #91 checks passed
- main CI passed at `e033ccf`
- Vercel, Netlify, and Cloudflare previews passed
- production SSO Registry policy `2026-08-17.1` is active for both Cook domains
- local lint, typecheck, targeted tests, and static build passed