### PR TITLE
fix(release): publish v2.0.0-beta.15 through EdgeOne

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cook",
   "type": "module",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "private": true,
   "packageManager": "pnpm@11.21.0",
   "engines": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,8 @@ trustPolicyExclude:
   - '@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1'
   # Official Ionic repository, maintainers, signature, and integrity verified.
   - '@capacitor/haptics@8.0.2'
+  # EdgeOne CLI 1.6.23 resolves this release; its upstream tag and commit are GPG-verified.
+  - chokidar@4.0.3
 
 packages:
   - docs


### PR DESCRIPTION
## What changed

- allow the exact verified `chokidar@4.0.3` release required by `edgeone@1.6.23`
- bump the retry release to `v2.0.0-beta.15`

## Root cause

The beta.14 release built successfully but pnpm 11 blocked EdgeOne CLI installation with `ERR_PNPM_TRUST_DOWNGRADE`. EdgeOne 1.6.23 resolves `chokidar ^4.0.1` to 4.0.3, whose npm release lacks provenance even though its upstream tag and commit are GPG-verified by the established maintainer.

## Safety

The repository keeps `trustPolicy: no-downgrade`; only the exact `chokidar@4.0.3` version is excluded. The EdgeOne CLI itself remains pinned to 1.6.23 in the release workflow.

## Validation

- npm package integrity and maintainer metadata verified
- upstream chokidar 4.0.3 tag and commit signature verified
- `pnpm dlx edgeone@1.6.23 --version` succeeds under the repository trust policy
- no lockfile changes