### PR TITLE
chore(release): v2.0.0-beta.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cook",
   "type": "module",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "private": true,
   "packageManager": "pnpm@11.21.0",
   "engines": {


### PR DESCRIPTION
## Summary

- bump the application prerelease version to `2.0.0-beta.17`
- prepare the refined cross-platform icon assets for production deployment

## Verification

- brand PR #95 passed lint, typecheck, tests, and deployment previews
- local production generation passed before merge